### PR TITLE
Update the pipeline deployment

### DIFF
--- a/kubernetes/deployments/pipeline.yaml
+++ b/kubernetes/deployments/pipeline.yaml
@@ -15,7 +15,7 @@ spec:
         app: pipeline
     spec:
       containers:
-      - image: gcr.io/hightowerlabs/pipeline
+      - image: gcr.io/devops-training-2/pipeline:1.0.0
         name: pipeline
         ports:
         - containerPort: 80


### PR DESCRIPTION
This commit updates the pipeline deployment container image to:

    gcr.io/devops-training-2/pipeline:1.0.0

Build ID: e8d4717b-661b-424b-ad0f-1e1dd66c16ae